### PR TITLE
Handling for non-ASCII characters in player aliases

### DIFF
--- a/obituary.py
+++ b/obituary.py
@@ -42,7 +42,7 @@ class Player(object):
 		self.deaths += [time]
 		
 	def aka(self, name):
-		self.aliases.add(name.strip('"'))
+		self.aliases.add(name.decode('utf-8').strip('"'))
 		
 	def dict(self):
 		return {'id':self.id,


### PR DESCRIPTION
This prevents LogViz from crashing when handling a player with a non-ASCII display name.
